### PR TITLE
refactor: update action to set temp json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
           mongo_db_uri: ${{ secrets.MONGO_DB_URI }}
           db_name: 'your_database_name'
           google_cloud_project: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
-          google_application_credentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          sa_key_json: ${{ secrets.GCP_SA_KEY }}
 ```
 
 ## ⚙️ Configuration
@@ -50,7 +50,7 @@ jobs:
 | `google_genai_use_vertexai` | ❌ | Use Vertex AI (`true`) or Gemini API key (`false`) | `true` |
 | `google_cloud_project` | ❌ | Google Cloud project name (required if using Vertex AI) | - |
 | `google_cloud_location` | ❌ | Google Cloud project location | `global` |
-| `google_application_credentials` | ❌ | Google service account key for ADC (required if using Vertex AI) | - |
+| `sa_key_json` | ❌ | Service Account key JSON (used to set `GOOGLE_APPLICATION_CREDENTIALS`) | - |
 | `google_api_key` | ❌ | Gemini API key (required if not using Vertex AI) | - |
 | `source_repo_path` | ❌ | Local path for source repository | `api` |
 | `readme_repo_path` | ❌ | Local path for documentation repository | `readme-doc` |
@@ -106,7 +106,7 @@ Create an environment in your GitHub repository (`Settings > Environments`) and 
 | `AGENT_RELEASE_TOKEN` | GitHub token with read access to the agent's latest release | Always |
 | `MONGO_DB_URI` | MongoDB connection string | Always |
 | `GOOGLE_CLOUD_PROJECT` | Google Cloud project name | Using Vertex AI |
-| `GOOGLE_APPLICATION_CREDENTIALS` | Google service account key (JSON content) | Using Vertex AI |
+| `GCP_SA_KEY` | Google service account key JSON content | Using Vertex AI |
 | `GOOGLE_API_KEY` | Google Gemini API key | Using Gemini API |
 
 ### Configuration Examples
@@ -121,8 +121,16 @@ with:
   mongo_db_uri: ${{ secrets.MONGO_DB_URI }}
   db_name: 'your_database_name'
   google_cloud_project: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
-  google_application_credentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+  sa_key_json: ${{ secrets.GCP_SA_KEY }}
 ```
+
+Behind the scenes, the action writes `sa_key_json` to a temp file and exports:
+
+```bash
+GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/gcp-key.json
+```
+
+This makes Application Default Credentials available to the agent without you managing files yourself.
 
 #### Using Gemini API Key
 

--- a/action.yaml
+++ b/action.yaml
@@ -29,8 +29,8 @@ inputs:
     description: "Google Cloud project location (set to 'global' if unsure)"
     required: false
     default: "global"
-  google_application_credentials:
-    description: "Google service account key for ADC (required if using Vertex AI)"
+  sa_key_json:
+    description: "Service Account key JSON (pass from secret)"
     required: false
   google_api_key:
     description: "Gemini API key (required if not using Vertex AI)"
@@ -79,18 +79,23 @@ runs:
       shell: bash
       run: pip install wheel_dist/*.whl
 
+    - name: Configure GOOGLE_APPLICATION_CREDENTIALS from sa_key_json
+      shell: bash
+      run: |
+        echo '${{ inputs.sa_key_json }}' > "$RUNNER_TEMP/gcp-key.json"
+        echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/gcp-key.json" >> "$GITHUB_ENV"
+
     - name: Run Readme Automation
       shell: bash
       env:
-        SOURCE_REPO_PATH: ${{ github.workspace }}/${{ inputs.source_repo_path }}
-        README_REPO_PATH: ${{ github.workspace }}/${{ inputs.readme_repo_path }}
         MONGO_DB_URI: ${{ inputs.mongo_db_uri }}
         DB_NAME: ${{ inputs.db_name }}
         GOOGLE_GENAI_USE_VERTEXAI: ${{ inputs.google_genai_use_vertexai }}
         GOOGLE_CLOUD_PROJECT: ${{ inputs.google_cloud_project }}
         GOOGLE_CLOUD_LOCATION: ${{ inputs.google_cloud_location }}
-        GOOGLE_APPLICATION_CREDENTIALS: ${{ inputs.google_application_credentials }}
         GOOGLE_API_KEY: ${{ inputs.google_api_key }}
+        SOURCE_REPO_PATH: ${{ github.workspace }}/${{ inputs.source_repo_path }}
+        README_REPO_PATH: ${{ github.workspace }}/${{ inputs.readme_repo_path }}
         SOURCE_REPO_URL: ${{ github.server_url }}/${{ github.repository }}
       run: |
         echo "=== RUNNING THE AGENT ==="


### PR DESCRIPTION
This pull request updates how Google Cloud service account credentials are handled for Vertex AI integration in both the documentation and the GitHub Action. The main change is switching from passing a file path (`google_application_credentials`) to passing the raw service account key JSON (`sa_key_json`), which the action then writes to a temporary file and sets up for Application Default Credentials. This simplifies configuration and improves security by not requiring manual file management.

**Action input and environment configuration:**

* Replaces the `google_application_credentials` input with `sa_key_json` in `action.yaml`, updating the description and usage accordingly. The workflow now writes the JSON to a temp file and sets `GOOGLE_APPLICATION_CREDENTIALS` automatically. [[1]](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL32-R33) [[2]](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR82-R98)

**Documentation updates:**

* Updates all references in `README.md` from `google_application_credentials` to `sa_key_json` and from `GOOGLE_APPLICATION_CREDENTIALS` to `GCP_SA_KEY` for secrets, clarifying how to configure the action and what secrets to set. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R53) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R109) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L124-R134)
* Adds documentation explaining that the action manages the credentials file automatically, making Application Default Credentials available without manual file handling.